### PR TITLE
refactor(ApiClient): add hooks to handle side effects, handle users/me 

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -4,7 +4,6 @@ import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import Modal from "@mui/material/Modal";
 import EditIcon from "@mui/icons-material/Edit";
-import { ApiClient } from "../../utils/ApiClient";
 import { InitialConfigType, LexicalComposer } from '@lexical/react/LexicalComposer';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
@@ -15,6 +14,7 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import SubmitButtonPlugin from "../lexical/SubmitButtonPlugin";
 import AutoFocusPlugin from "../lexical/AutoFocusPlugin";
 import { EditorProps } from "./types";
+import { useApiClient } from "../../hooks/useApiClient";
 
 function Editor( { resource }: EditorProps ) {
   const composerConfig: InitialConfigType = {
@@ -25,9 +25,10 @@ function Editor( { resource }: EditorProps ) {
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
+  const api = useApiClient();
 
   const handleSubmit = async (editorState: EditorState) => {
-    await ApiClient.createNote({content: JSON.stringify(editorState.toJSON()) }, resource);
+    await api.createNote({content: JSON.stringify(editorState.toJSON()) }, resource);
     // TODO: handle errors
     setOpen(false);
     // TODO: re-fetch data instead of refreshing the page.

--- a/src/components/user/UserLoginButton.tsx
+++ b/src/components/user/UserLoginButton.tsx
@@ -1,26 +1,27 @@
 import { Box, Button, IconButton, Tooltip } from "@mui/material";
 import PersonIcon from '@mui/icons-material/Person';
-import { useUser, useUserDispatch } from "../../contexts/UserContext";
+import { useUserContext } from "../../contexts/UserContext";
 import { MouseEventHandler, useState } from "react";
 import { UserLoginModal } from "./UserLoginModal";
-import { ApiClient } from "../../utils/ApiClient";
+import { useApiClient } from "../../hooks/useApiClient";
 
 export function UserLoginButton() {
     const [isDialogOpen, setDialogOpen] = useState(false);
-    const user = useUser();
-    const dispatch = useUserDispatch();
+    const context = useUserContext();
+    const api = useApiClient();
     
-    const handleLogin: MouseEventHandler = async () => {        
+    const handleLogin: MouseEventHandler = async (event) => {  
+        event.preventDefault();      
         setDialogOpen(true);
     }
 
-    const handleLogout: MouseEventHandler = async () => {        
-        await ApiClient.logout();
-        dispatch({type: "loggedOut"})
+    const handleLogout: MouseEventHandler = async (event) => {        
+        event.preventDefault();
+        api.logout(); // user context will be updated
     }
 
     const renderLoginOrLogoutBtn = () => {
-        if ( user.isLogged ) {
+        if ( context.isLogged ) {
             return <Button variant="outlined" onClick={handleLogout}>Logout</Button>
         }
         return <Button variant="outlined" onClick={handleLogin}>Login</Button>
@@ -28,12 +29,12 @@ export function UserLoginButton() {
 
     return (
     <Box className="flex gap-2 items-center">
-        <Tooltip title={user.status}>
+        <Tooltip title={context.status}>
             <IconButton>
                 <PersonIcon />
             </IconButton>
         </Tooltip>
-        {user.username && <span>{user.username}</span>}
+        {context.username && <span>{context.username}</span>}
         {renderLoginOrLogoutBtn()}        
         <span></span>
         <UserLoginModal open={isDialogOpen} onClose={() => setDialogOpen(false)}/>

--- a/src/components/user/UserLoginForm.tsx
+++ b/src/components/user/UserLoginForm.tsx
@@ -45,6 +45,7 @@ export function UserLoginForm({ onLogged }: Props) {
                 dispatch({ type: 'error', message: "unable to log in"})
             }            
         }
+        event?.target.reset();
     }
 
     return (

--- a/src/components/user/UserLoginForm.tsx
+++ b/src/components/user/UserLoginForm.tsx
@@ -45,7 +45,6 @@ export function UserLoginForm({ onLogged }: Props) {
                 dispatch({ type: 'error', message: "unable to log in"})
             }            
         }
-        event?.target.reset();
     }
 
     return (

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -32,7 +32,7 @@ export function UserProvider({ children }: PropsWithChildren) {
   );
 }
 
-export function useUser(): State {
+export function useUserContext(): State {
   const context = useContext(Context);
   if ( context == null) throw new Error("Unable to use UserContext, did you wrapped this component in a UserProvider?");
   return context;

--- a/src/hooks/useApiClient.tsx
+++ b/src/hooks/useApiClient.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect } from "react";
+import { useUserContext, useUserDispatch } from "../contexts/UserContext";
+import { UserCreate, UserCredentials } from "../types/user";
+import { ApiClient } from "../utils/ApiClient";
+
+/**
+ * Wraps ApiClient functions as a React hook.
+ * Each call may have a side effect on UserContext.
+ * 
+ * ReactComponent <----> useApiClient <-----> ApiClient <-----> API
+ *        ^                     v
+ *        |                     |
+ *        ----- UserContext <----
+ * 
+ * Condider bringing new functionnality here by calling ApiClient's functions.
+ * But, implement the maximum as pure functions in ApiClient instead of here.
+ */
+export function useApiClient() {
+    const context = useUserContext();
+    const dispatch = useUserDispatch();
+
+    /** Query users/me in case user context state is disconnected */
+    useEffect( () => {
+        async function fetch() {
+            if ( !context.isLogged ) {
+                console.debug("Automatic getme()...")
+                const _user = await ApiClient.getme();
+                if ( _user ) {
+                    console.debug("Automatic getme() success", _user)
+                    dispatch({ type: "loggedIn", username: _user.username })
+                }
+            }
+        }
+        fetch();
+    }, [])
+
+    /**
+     * SignIn using credentials and update user context accordingly
+     */
+    const signup = useCallback( async (userCreate: UserCreate): Promise<boolean> => {
+        const success = await ApiClient.signup(userCreate);
+        if ( success ) {
+            dispatch({ type: 'loggedIn', username: userCreate.username})
+        } else {
+            dispatch({ type: 'error', message: "Unable to sign in"})
+        }
+        return success;
+    }, [context])
+
+    /**
+     * Login using credentials and update user context accordingly
+     */
+    const login = useCallback( async (credentials: UserCredentials): Promise<boolean> => {
+        const success = await ApiClient.login(credentials);
+        if ( success ) {
+            dispatch({ type: 'loggedIn', username: credentials.username})
+        } else {
+            dispatch({ type: 'error', message: "Unable to log in"})
+        }
+        return success;     
+    }, [context])
+    
+    /**
+     * Logout using credentials and update user context accordingly
+     */
+    const logout = useCallback( async (): Promise<boolean> => {
+        if ( context.isLogged == null || context.username == null) {
+            console.warn(`Unable to logout, no user is currently connected`)
+            return false;
+        }
+        const success = await ApiClient.logout();
+        if ( success ) {
+            dispatch({ type: 'loggedOut' })
+        } else {
+            dispatch({ type: 'error', message: "Unable to log out"})
+        }
+        return success;     
+    }, [context])
+    
+    const createNote = ApiClient.createNote; // TODO: create a NoteContext to store the current Resource with its Notes
+    const getOrCreateResource = ApiClient.getOrCreateResource; // same
+
+    return {
+        signup,
+        login,
+        logout,
+        createNote,
+        getOrCreateResource,
+    }
+}

--- a/src/hooks/useApiClient.tsx
+++ b/src/hooks/useApiClient.tsx
@@ -12,7 +12,7 @@ import { ApiClient } from "../utils/ApiClient";
  *        |                     |
  *        ----- UserContext <----
  * 
- * Condider bringing new functionnality here by calling ApiClient's functions.
+ * Consider bringing new functionality here by calling ApiClient's functions.
  * But, implement the maximum as pure functions in ApiClient instead of here.
  */
 export function useApiClient() {
@@ -35,14 +35,14 @@ export function useApiClient() {
     }, [])
 
     /**
-     * SignIn using credentials and update user context accordingly
+     * Sign up using credentials and update user context accordingly
      */
     const signup = useCallback( async (userCreate: UserCreate): Promise<boolean> => {
         const success = await ApiClient.signup(userCreate);
         if ( success ) {
             dispatch({ type: 'loggedIn', username: userCreate.username})
         } else {
-            dispatch({ type: 'error', message: "Unable to sign in"})
+            dispatch({ type: 'error', message: "Unable to sign up"})
         }
         return success;
     }, [context])

--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -5,14 +5,15 @@ import { Note } from "../components/note";
 import { Editor } from "../components/editor/Editor";
 import { Filters } from "../components/filters/Filters";
 import { useQuery } from "react-query";
-import { ApiClient } from "../utils/ApiClient";
 import { RESOURCE_NOT_FOUND, RESOURCE_PLACEHOLDER } from "../mocks/resource";
 import { TopBar } from "../components/top-bar";
 import { useDebouncedCallback } from "use-debounce";
 import { useSearchParams } from "react-router-dom";
 import { UserLoginButton } from "../components/user/UserLoginButton";
+import { useApiClient } from "../hooks/useApiClient";
 
 function Notes() {
+  const api = useApiClient();
   /** searchParams as state (we store URL state in it) */
   const [searchParams, setSearchParams] = useSearchParams({ url: '' })
   const url = searchParams.get('url')
@@ -30,7 +31,7 @@ function Notes() {
       if (!params.url) {
         return RESOURCE_PLACEHOLDER;
       }
-      const resource_or_null = await ApiClient.getOrCreateResource(params.url);
+      const resource_or_null = await api.getOrCreateResource(params.url);
       return resource_or_null ?? RESOURCE_NOT_FOUND;
     },
     {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,11 @@
+export type User = {
+    uuid: string,
+    username: string,
+    email: string,
+    is_active: true,
+    created_at: string
+}
+
 export type UserCredentials = {
     username: string;
     password: string;

--- a/src/utils/ApiClient.ts
+++ b/src/utils/ApiClient.ts
@@ -2,7 +2,7 @@ import { api } from '../types/api';
 import { API_PATH, env } from "../config";
 import axios, { AxiosInstance, AxiosResponse, HttpStatusCode } from 'axios';
 import mem from 'mem'; // Memoized
-import { UserCreate, UserCredentials } from '../types/user';
+import { User, UserCreate, UserCredentials } from '../types/user';
 
 export class ApiError extends Error {
     reason: any;
@@ -15,6 +15,8 @@ export class ApiError extends Error {
 
 /**
  * Set of function to deal with the backend API.
+ * Consider using the hook useApiClient instead, this Api is stateless
+ * (except for the access_token which is stored in the local storage).
  */
 export namespace ApiClient {
 
@@ -94,9 +96,23 @@ export namespace ApiClient {
         }   
     }
 
-    /** TODO (not implemented on backend side) */
+    export async function getme(): Promise<User | null> {
+        try {
+            // Note that if it fails, the interceptor migh be able to catch it and
+            // grab the token from the local storaga and retry (see interceptors above)
+            return await httpClient.get(`${API_PATH.USERS}/me`);
+        } catch ( error: any) {
+            console.error(`Unable to get current user`, error)
+            return null;
+        }
+    }
+
+    /**
+     * TODO: nothing implemented on the backend side, should be manipulate this token manually on the frontend...?
+     */
     export async function logout(): Promise<boolean> {
-        throw new Error("Not implemented yet")    
+        localStorage.removeItem("access_token");
+        return true;    
     }
 
     /**

--- a/src/utils/ApiClient.ts
+++ b/src/utils/ApiClient.ts
@@ -213,7 +213,7 @@ export namespace ApiClient {
             return response.data;
         } catch (error: any ) {    
             // The only error we allow is a 404, otherwize we return a null
-            if (error.status !== HttpStatusCode.NotFound) {
+            if (!error.response || error.response.status !== HttpStatusCode.NotFound) {
                 console.error('Unable to get the resource', error)
                 return null;                          
             }
@@ -226,7 +226,7 @@ export namespace ApiClient {
             return response.data;
         } catch (error: any) {
             // The only error we allow is 409, it signify an other user created the same resource (race condition)
-            if (error.status !== HttpStatusCode.Conflict) {
+            if (!error.response || error.response.status !== HttpStatusCode.Conflict) {
                 console.error('Unable to create the resource', error)
                 return null;            
             }


### PR DESCRIPTION
Added few little things in this branch:
- Auto connect when page loads (grabs the token from storage, and fetch user)
- Allows to signup
- Allow to logout (clear storage and user context)
- Separate ApiClient from components by introducing: useUserContext and useApiClient hooks. Those hooks handle API querying and maintaining a coherent user state.