### PR TITLE
feat(alerts): add alert overlay and alert context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,12 @@
         "@mui/material": "^5.13.5",
         "@tanstack/react-query": "^4.29.7",
         "@tanstack/react-query-devtools": "^4.29.7",
+        "@types/moment": "^2.13.0",
         "@types/slate": "^0.47.15",
+        "@types/uuid": "^9.0.8",
         "axios": "^1.6.7",
         "mem": "^10.0.0",
+        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.0",
@@ -25,7 +28,8 @@
         "slate": "^0.102.0",
         "slate-history": "^0.100.0",
         "slate-react": "^0.102.0",
-        "use-debounce": "^10.0.0"
+        "use-debounce": "^10.0.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",
@@ -1122,6 +1126,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
       "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA=="
     },
+    "node_modules/@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
+      "deprecated": "This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!",
+      "dependencies": {
+        "moment": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -1186,6 +1199,11 @@
         "@types/react": "*",
         "immutable": "^3.8.2"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.59.6",
@@ -3024,6 +3042,14 @@
         "node": "*"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4193,6 +4219,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "4.3.9",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "@mui/material": "^5.13.5",
     "@tanstack/react-query": "^4.29.7",
     "@tanstack/react-query-devtools": "^4.29.7",
+    "@types/moment": "^2.13.0",
     "@types/slate": "^0.47.15",
+    "@types/uuid": "^9.0.8",
     "axios": "^1.6.7",
     "mem": "^10.0.0",
+    "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.0",
@@ -27,7 +30,8 @@
     "slate": "^0.102.0",
     "slate-history": "^0.100.0",
     "slate-react": "^0.102.0",
-    "use-debounce": "^10.0.0"
+    "use-debounce": "^10.0.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import NotFound from "./pages/404";
 import { ROUTER_PATH } from "./config";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { UserProvider } from "./contexts/UserContext";
+import { AlertProvider } from "./contexts/AlertContext";
+import { AlertOverlay } from "./components/alerts/AlertOverlay";
 
 const theme = createTheme({
   typography: {
@@ -15,10 +17,13 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <UserProvider>
-        <Routes>
-          <Route path={ROUTER_PATH.NOTES} element={<Notes />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <AlertProvider>   
+          <AlertOverlay/>       
+          <Routes>
+            <Route path={ROUTER_PATH.NOTES} element={<Notes />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>          
+        </AlertProvider>
       </UserProvider>      
     </ThemeProvider>
   );

--- a/src/components/alerts/AlertOverlay.tsx
+++ b/src/components/alerts/AlertOverlay.tsx
@@ -53,6 +53,7 @@ export function AlertOverlay() {
             
             return (
                 <MyAlert
+                    key={alert.uuid}
                     alert={alert}
                     onClose={handleCloseAlert}
                     delayInMs={delayInMs}
@@ -70,8 +71,7 @@ type MyAlertProps = {
 function MyAlert( {alert, onClose: handleCloseAlert, delayInMs}: MyAlertProps) {
 
     return (
-    <Alert
-        key={alert.uuid}
+    <Alert        
         className={`p-5 pointer-events-auto cursor-auto w-100`}
         severity={alert.severity}
         onClose={() => handleCloseAlert(alert.uuid)}

--- a/src/components/alerts/AlertOverlay.tsx
+++ b/src/components/alerts/AlertOverlay.tsx
@@ -1,0 +1,39 @@
+import MuiAlert from "@mui/material/Alert";
+import { AlertData, useAlertContext, useAlertDispatch } from "../../contexts/AlertContext"
+
+export function AlertOverlay() {
+    const context = useAlertContext();
+    const dispatch = useAlertDispatch();
+
+    const handleCloseAlert = (alert: AlertData) => {
+        dispatch({type: "delete", alert: alert });
+    }
+
+    return <div
+        className="pointer-events-none flex flex-col justify-items-end gap-2 p-2"
+        style={{ position: "fixed", zIndex: 100, right: 0, bottom: 0 }}
+        >
+        {context.alerts.map( alert => {
+            return <Alert
+                alert={alert}
+                onClose={handleCloseAlert} />
+        })}
+    </div>
+}
+
+type AlertProps = {
+    onClose: (alert: AlertData) => void;
+    alert: AlertData;
+}
+
+function Alert({onClose, alert}: AlertProps) {
+    return (
+    <MuiAlert
+        className="p-5 pointer-events-auto cursor-pointer"
+        severity={alert.severity}
+        onClick={() => onClose(alert)}
+    >
+        {alert.message}
+    </MuiAlert>
+    )
+}

--- a/src/components/alerts/AlertOverlay.tsx
+++ b/src/components/alerts/AlertOverlay.tsx
@@ -1,28 +1,38 @@
 import Alert from "@mui/material/Alert";
-import AlertTitle from "@mui/material/AlertTitle";
 import { AlertData, useAlertContext, useAlertDispatch } from "../../contexts/AlertContext"
 import { useClock } from "../../hooks/useClock";
 import Box from "@mui/material/Box";
-import { Chip } from "@mui/material";
-import moment from "moment";
+import { AlertTitle, Chip } from "@mui/material";
 
 /** Define the delay (in ms) to hide an alert */
-const AUTO_HIDE_DELAY = {
+const AUTO_HIDE_TRANSITION_START = {
     info: 3000,
     success: 3000,
     warning: 10000,
     error: Number.POSITIVE_INFINITY,
 } as const;
 
-/** Delay to show "X sec ago" */
-const X_SECONDS_AGO_DELAY = 3000;
+/**
+ * Format a delay as "now", "x sec ago", or "x min ago"
+ */
+const formatDelay = (delayInMs: number) => {
+    if ( delayInMs < 5_000 ) {
+        return "just now"
+    }
+    
+    if ( delayInMs < 60_000 ) {
+        return `${ Math.floor(delayInMs / 1_000) * 1}s ago`;
+    } else {
+        return `${Math.floor(delayInMs / 60_000)}m ago`;
+    }
+}
 
 /**
  * Overlay to display the alerts.
  * Is using 100% of the parent's space.
  */
 export function AlertOverlay() {
-    const context = useAlertContext();
+    const { alerts } = useAlertContext();
     const dispatch = useAlertDispatch();
     const { date: currentDate } = useClock({ intervalInMs: 1000 })
 
@@ -30,38 +40,55 @@ export function AlertOverlay() {
         dispatch({type: "delete", uuid });
     }
 
-    return <div
+    return <Box
             className="pointer-events-none flex flex-col justify-items-end gap-2 p-2"
-            style={{ position: "fixed", zIndex: 100, right: 0, bottom: 0 }}
+            sx={{ position: "fixed", zIndex: 100, right: 0, top: 60}}
         >
-        {context.alerts
-                .map( alert => {
-            const delayInMs = Math.round( currentDate.diff(alert.date)) ;
+        {alerts.map( alert => {
+            const delayInMs = Math.round( currentDate.diff(alert.date)) ;            
             
-            if ( delayInMs > AUTO_HIDE_DELAY[alert.severity] ) {
-                return <></>
+            if ( delayInMs > AUTO_HIDE_TRANSITION_START[alert.severity] ) {
+                return;
             }
-
+            
             return (
-                <Alert
-                    key={alert.uuid}
-                    className="p-5 pointer-events-auto cursor-pointer"
-                    severity={alert.severity}
-                    onClose={() => handleCloseAlert(alert.uuid)}
-                >
-                    <AlertTitle className="flex gap-1 justify-between">
-                        {alert.title}
-                        {alert.count > 1 && <Chip label={`${alert.count} times`} size="small"/>}
-                    </AlertTitle>
-                    <Box className="flex flex-col gap-1">
-                        <Box>{alert.message}</Box>
-                        { delayInMs >= X_SECONDS_AGO_DELAY &&
-                        <Box className="opacity-25">
-                            {moment().millisecond(delayInMs).format("s [sec ago]")}
-                        </Box>}
-                    </Box>
-                </Alert>
-            )
+                <MyAlert
+                    alert={alert}
+                    onClose={handleCloseAlert}
+                    delayInMs={delayInMs}
+                />)
         })}
-    </div>
+    </Box>
 }
+
+type MyAlertProps = {
+    alert: AlertData;
+    onClose: (uuid: AlertData['uuid']) => void;
+    delayInMs: number
+}
+
+function MyAlert( {alert, onClose: handleCloseAlert, delayInMs}: MyAlertProps) {
+
+    return (
+    <Alert
+        key={alert.uuid}
+        className={`p-5 pointer-events-auto cursor-auto w-100`}
+        severity={alert.severity}
+        onClose={() => handleCloseAlert(alert.uuid)}
+    >
+        {/** Header */}
+        <AlertTitle className="flex gap-5 justify-between items-baseline">
+            <h1>{alert.title}</h1>
+            {alert.severity == "error" && alert.count > 1 && <Chip label={`x${alert.count}`} variant="outlined" size="small" />}
+            <span className="w-auto opacity-25">{formatDelay(delayInMs)}</span>
+        </AlertTitle>
+
+        {/** Content */}
+        <Box className="flex gap-2 justify-between">
+            <p>{alert.message}</p>
+        </Box>
+
+    </Alert>
+    );
+}
+

--- a/src/components/alerts/AlertOverlay.tsx
+++ b/src/components/alerts/AlertOverlay.tsx
@@ -1,6 +1,10 @@
 import MuiAlert from "@mui/material/Alert";
 import { AlertData, useAlertContext, useAlertDispatch } from "../../contexts/AlertContext"
 
+/**
+ * Overlay to display the alerts.
+ * Is using 100% of the parent's space.
+ */
 export function AlertOverlay() {
     const context = useAlertContext();
     const dispatch = useAlertDispatch();

--- a/src/components/alerts/AlertOverlay.tsx
+++ b/src/components/alerts/AlertOverlay.tsx
@@ -1,5 +1,21 @@
-import MuiAlert from "@mui/material/Alert";
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
 import { AlertData, useAlertContext, useAlertDispatch } from "../../contexts/AlertContext"
+import { useClock } from "../../hooks/useClock";
+import Box from "@mui/material/Box";
+import { Chip } from "@mui/material";
+import moment from "moment";
+
+/** Define the delay (in ms) to hide an alert */
+const AUTO_HIDE_DELAY = {
+    info: 3000,
+    success: 3000,
+    warning: 10000,
+    error: Number.POSITIVE_INFINITY,
+} as const;
+
+/** Delay to show "X sec ago" */
+const X_SECONDS_AGO_DELAY = 3000;
 
 /**
  * Overlay to display the alerts.
@@ -8,36 +24,44 @@ import { AlertData, useAlertContext, useAlertDispatch } from "../../contexts/Ale
 export function AlertOverlay() {
     const context = useAlertContext();
     const dispatch = useAlertDispatch();
+    const { date: currentDate } = useClock({ intervalInMs: 1000 })
 
-    const handleCloseAlert = (alert: AlertData) => {
-        dispatch({type: "delete", alert: alert });
+    const handleCloseAlert = (uuid: AlertData['uuid']) => {
+        dispatch({type: "delete", uuid });
     }
 
     return <div
-        className="pointer-events-none flex flex-col justify-items-end gap-2 p-2"
-        style={{ position: "fixed", zIndex: 100, right: 0, bottom: 0 }}
+            className="pointer-events-none flex flex-col justify-items-end gap-2 p-2"
+            style={{ position: "fixed", zIndex: 100, right: 0, bottom: 0 }}
         >
-        {context.alerts.map( alert => {
-            return <Alert
-                alert={alert}
-                onClose={handleCloseAlert} />
+        {context.alerts
+                .map( alert => {
+            const delayInMs = Math.round( currentDate.diff(alert.date)) ;
+            
+            if ( delayInMs > AUTO_HIDE_DELAY[alert.severity] ) {
+                return <></>
+            }
+
+            return (
+                <Alert
+                    key={alert.uuid}
+                    className="p-5 pointer-events-auto cursor-pointer"
+                    severity={alert.severity}
+                    onClose={() => handleCloseAlert(alert.uuid)}
+                >
+                    <AlertTitle className="flex gap-1 justify-between">
+                        {alert.title}
+                        {alert.count > 1 && <Chip label={`${alert.count} times`} size="small"/>}
+                    </AlertTitle>
+                    <Box className="flex flex-col gap-1">
+                        <Box>{alert.message}</Box>
+                        { delayInMs >= X_SECONDS_AGO_DELAY &&
+                        <Box className="opacity-25">
+                            {moment().millisecond(delayInMs).format("s [sec ago]")}
+                        </Box>}
+                    </Box>
+                </Alert>
+            )
         })}
     </div>
-}
-
-type AlertProps = {
-    onClose: (alert: AlertData) => void;
-    alert: AlertData;
-}
-
-function Alert({onClose, alert}: AlertProps) {
-    return (
-    <MuiAlert
-        className="p-5 pointer-events-auto cursor-pointer"
-        severity={alert.severity}
-        onClick={() => onClose(alert)}
-    >
-        {alert.message}
-    </MuiAlert>
-    )
 }

--- a/src/components/user/UserLoginModal.tsx
+++ b/src/components/user/UserLoginModal.tsx
@@ -21,7 +21,7 @@ export function UserLoginModal(props: Props) {
     }
 
     return (
-        <Dialog {...props}>
+        <Dialog {...props} hideBackdrop>
             <Box sx={{ width: 350 }}>
                 <UserLoginForm onLogged={handleUserLogged} />
             </Box>

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -59,7 +59,7 @@ function userReducer(state: State, action: Action): State {
   switch (action.type) {
     case 'push': {
 
-      // If a similar alert exists, simply increment count and update date
+      // If a similar alert exists, we replace it with update values
       if ( state.alerts.length > 0) {
         const last = state.alerts[0];
         if ( last.severity === action.alert.severity && last.title === action.alert.title && last.message === action.alert.message ) {
@@ -83,23 +83,16 @@ function userReducer(state: State, action: Action): State {
         date: moment(),
         count: 1
       };
-      const newAlerts = [newAlert, ...state.alerts ];
-
-      // Shrink alerts when history is too large
-      while ( newAlerts.length > state.maxHistoryLength ) {
-          newAlerts.pop();
-      }
 
       return {
           ...state,
-          alerts: newAlerts
+          alerts: [newAlert, ...state.alerts.slice(0, state.maxHistoryLength-1) ] // New alert + 9 older
       }
     }
     case "delete": {
-      const newAlerts = state.alerts.filter( _alert => _alert.uuid !== action.uuid )  
       return {
         ...state,
-        alerts: newAlerts
+        alerts: state.alerts.filter( _alert => _alert.uuid !== action.uuid )
       }
     }
   }  

--- a/src/contexts/AlertContext.tsx
+++ b/src/contexts/AlertContext.tsx
@@ -1,0 +1,95 @@
+import { Dispatch, PropsWithChildren, createContext, useContext, useReducer } from 'react';
+
+export type AlertData = {  
+    date: Date;
+    severity: 'success' | 'info' | 'warning' | 'error'; // Matches with mui's alert's
+    title: string;
+    message: string;
+    count: number;
+}
+
+type State = {
+  /** The last alert (sorted from recent to older) */
+  alerts: Array<AlertData>;
+  /** Alert history length (default is 10) */
+  maxHistoryLength: number;
+}
+
+const initialState: State = {
+  alerts: [],
+  maxHistoryLength: 10
+}
+
+type Action = { type: 'push', alert: Omit<AlertData, 'date' | 'count'> }
+            | { type: 'delete', alert: AlertData }
+            
+const Context = createContext<State | null>(null);
+
+const DispatchContext = createContext<Dispatch<Action> | null>(null);
+
+export function AlertProvider({ children }: PropsWithChildren) {
+  const [state, dispatch] = useReducer(userReducer, initialState);
+
+  return (
+    <Context.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </Context.Provider>
+  );
+}
+
+export function useAlertContext(): State {
+  const context = useContext(Context);
+  if ( context == null) throw new Error("Unable to use AlertContext, did you wrapped this component in a AlertProvider?");
+  return context;
+}
+
+export function useAlertDispatch(): Dispatch<Action> {
+  const dispatch = useContext(DispatchContext);
+  if ( dispatch == null) throw new Error("Unable to use AlertDispatchContext, did you wrapped this component in a AlertProvider?");
+  return dispatch;
+}
+
+function userReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'push': {
+
+      // If a similar alert exists, simply increment count
+      if ( state.alerts.length > 0) {
+        const last = state.alerts[0];
+        if ( last.severity === action.alert.severity && last.title === action.alert.title && last.message === action.alert.message ) {
+          const newAlerts = [...state.alerts];
+          newAlerts[0] = {
+            ...last,
+            count: last.count + 1
+          }
+          return {
+            ...state,
+            alerts: newAlerts
+          }        
+        }
+      }
+
+      // Insert it first
+      const newAlerts = [{...action.alert, date: new Date(), count: 1}, ...state.alerts ];
+
+      // Shrink alerts when history is too large
+      while ( newAlerts.length > state.maxHistoryLength ) {
+          newAlerts.pop();
+      }
+
+      return {
+          ...state,
+          alerts: newAlerts
+      }
+    }
+    case "delete": {
+      const newAlerts = state.alerts.filter( _notif => _notif !== action.alert )  
+      return {
+        ...state,
+        alerts: newAlerts
+      }
+    }
+  }  
+}

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -14,15 +14,12 @@ type State = {
   status: Status;
   /** User's status as a string */
   statusMessage: string;
-  /** Last error message, may be cleared by an Action dispatch */
-  errorMessage?: string;
 }
 
 type Action = { type: 'loggedIn', user: User }
             | { type: 'loggedOut' }
             | { type: 'logging' }
-            | { type: 'reset' }
-            | { type: 'error', message: string }
+            | { type: 'reset' };
             
 const Context = createContext<State | null>(null);
 
@@ -62,12 +59,6 @@ function userReducer(state: State, action: Action): State {
       return {
         ...initialState
       }
-    }
-    case 'error': {
-        return {
-            ...state,
-            errorMessage: action.message
-        }
     }
     case 'logging': {
         return {

--- a/src/hooks/useClock.tsx
+++ b/src/hooks/useClock.tsx
@@ -1,0 +1,22 @@
+import moment, { Moment } from "moment";
+import { useEffect, useState } from "react";
+
+type Props = {
+    /** Clock interval precision in ms */
+    intervalInMs: number
+}
+
+/**
+ * Wraps the current date as a State.
+ * Date is stored as a Moment object and is updated by regular intervals
+ */
+export function useClock({ intervalInMs }: Props) {
+    const [date, setDate] = useState<Moment>(moment());
+    
+    useEffect(() => {
+        const interval = setInterval(() => { setDate(moment()); }, intervalInMs);
+        return () => clearInterval(interval);
+    }, [intervalInMs]);
+
+    return { date, setDate }
+}

--- a/src/utils/ApiClient.ts
+++ b/src/utils/ApiClient.ts
@@ -5,10 +5,12 @@ import mem from 'mem'; // Memoized
 import { User, UserCreate, UserCredentials } from '../types/user';
 
 export class ApiError extends Error {
-    reason: any;
-    constructor(message: string, reason: any) {
-        super(message);
-        this.reason = reason;
+    name: string;
+    error: any;
+    constructor(error: any) {
+        super(error?.response?.data?.detail ?? error.message);
+        this.name = error.name;
+        this.error = error;
     }
 }
 
@@ -87,28 +89,26 @@ export namespace ApiClient {
     /**
      * Create a new user with the provided user information.
      */
-    export async function signup(user: UserCreate): Promise<User | null> {
+    export async function signup(user: UserCreate): Promise<User> {
         try {
             await httpClient.post(`${API_PATH.USERS}`, user);
-        } catch (error: any) {
-            console.error(`Unable to signup`, error)
-            return null;
-        }   
-        return ApiClient.getme();
+            return ApiClient.getme();
+        } catch (error: unknown) {
+            throw new ApiError(error);
+        }        
     }
 
     /**
      * Get the current user
      */
-    export async function getme(): Promise<User | null> {
+    export async function getme(): Promise<User> {
         try {
             // Note that if it fails, the interceptor might be able to catch it and
             // grab the token from the local storage and retry (see interceptors above)
             const response = await httpClient.get(`${API_PATH.USERS}/me`);
             return response.data
-        } catch (error: any) {
-            // error skipped on purpose, they are very annoying and http errors can also be seen in the network tab
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
     }
 
@@ -126,7 +126,7 @@ export namespace ApiClient {
      * access_token is stored in the local storage as "access_token" and will be automatically
      * injected (see interceptors above)
      */
-    export async function login({username, password}: UserCredentials): Promise<User | null> {
+    export async function login({username, password}: UserCredentials): Promise<User> {
         if (!username || !password) {
             throw new Error("Username and/or password is empty or undefined")
         }
@@ -139,9 +139,8 @@ export namespace ApiClient {
                 { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
             );
             localStorage.setItem("access_token", response.data.access_token);
-        } catch (error: any) {
-            console.error(`Unable to login`, error)
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
         
         // 2) get current user
@@ -153,13 +152,12 @@ export namespace ApiClient {
      * @param url The url of the Resource.
      * @returns a Resource or null if it fails
      */
-    export async function createResource(url: api.Resource['url']): Promise<api.Resource | null> {
+    export async function createResource(url: api.Resource['url']): Promise<api.Resource> {
         try {
             const response = await internal.createResource(url);
             return response.data;
-        } catch (error: any) {
-            console.error(`Unable to createResource`, error)
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
     }
 
@@ -168,13 +166,12 @@ export namespace ApiClient {
      * @param note   The Note to create.
      * @param url    The URL of the related Resource.
      */
-    export async function createNote(note: api.NotePOST, resource: api.Resource): Promise<api.Note | null> {
+    export async function createNote(note: api.NotePOST, resource: api.Resource): Promise<api.Note> {
         try {
             const response = await internal.createNote(note, resource);
             return response.data;
-        } catch (error: any) {
-            console.error(`Unable to createNote`, error)
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
     }
 
@@ -182,13 +179,12 @@ export namespace ApiClient {
      * Get all the notes related to a given Resource
      * @param url   The url of the related Resource. If not set, all notes will be returned
      */
-    export async function getNotes(resource: api.Resource): Promise<api.Note[] | null> {
+    export async function getNotes(resource: api.Resource): Promise<api.Note[]> {
         try {
             const response = await internal.getNotes(resource);
             return response.data;
-        } catch (error: any) {
-            console.error(`Unable to getNotes`, error)
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
     }
 
@@ -197,13 +193,12 @@ export namespace ApiClient {
      * @param url The url of the Resource.
      * @returns a Resource or null if it fails
      */
-    export async function getResource(url: string): Promise<api.Resource | null> {
+    export async function getResource(url: string): Promise<api.Resource> {
         try {
             const response = await internal.getResource(url);
             return response.data;
-        } catch (error: any) {
-            console.error(`Unable to getResource`, error)
-            return null;
+        } catch (error: unknown) {
+            throw new ApiError(error);
         }
     }
 
@@ -213,7 +208,7 @@ export namespace ApiClient {
      * @param url The url of the resource
      * @returns a Resource or null if it fails
      */
-    export async function getOrCreateResource(url: string): Promise<api.Resource | null> {
+    export async function getOrCreateResource(url: string): Promise<api.Resource> {
 
         // First, we try to get the resource (may exist)
         try {
@@ -221,10 +216,9 @@ export namespace ApiClient {
             const response = await internal.getResource(url);
             return response.data;
         } catch (error: any ) {    
-            // The only error we allow is a 404, otherwize we return a null
+            // The only error we allow is a 404, otherwize we throw an
             if (!error.response || error.response.status !== HttpStatusCode.NotFound) {
-                console.error('Unable to get the resource', error)
-                return null;                          
+                throw new ApiError(error);                          
             }
         }
 
@@ -236,8 +230,7 @@ export namespace ApiClient {
         } catch (error: any) {
             // The only error we allow is 409, it signify an other user created the same resource (race condition)
             if (!error.response || error.response.status !== HttpStatusCode.Conflict) {
-                console.error('Unable to create the resource', error)
-                return null;            
+                throw new ApiError(error);           
             }
         }
 
@@ -246,8 +239,7 @@ export namespace ApiClient {
             const response = await internal.getResource(url);
             return response.data;
         } catch (error: any) {
-            console.error(`Unable to getOrCreateResource`, error);
-            return null;
+            throw new ApiError(error); 
         }
     }
 


### PR DESCRIPTION
# Description

This PR add a simple alert system.
Bullet point to explain the feature:
- `AlertContext` store the last nth alerts, user can push and delete an alert using `dispatchAlert` hook.
- `AlertOverlay` has been added on top of any route to display the last nth alerts.
- `ApiClient` return the expected object or throw  an `ApiClientError` (previously named `ApiError`  )
- `useApiClient` functions return the expected object or null, and convert any caught error to an Alert.

# Screenshots

The Alerts look like that in the UI:

Simple info:
![image](https://github.com/notes-org/notes-frontend/assets/942052/0e627d72-e792-4905-a388-116c65b0ddbd)

Error (message comes from API's response "details" field):
![image](https://github.com/notes-org/notes-frontend/assets/942052/054c5f65-8853-49d3-a059-b721bcd227d6)

Note that, when multiple identical alerts are pushed in a row, only one is stored, but a counter is incremented (see "x3" above)

There is a delay to show when the alert appeared for the last time ("just now", "5s ago", ...):
![image](https://github.com/notes-org/notes-frontend/assets/942052/6f802976-8034-40fa-8bad-b7d9a2bff2a7)

The thing I like is error feedback is handled globally, no need to add more details to the forms. Example (which highlight a problem, since we should not display the form until user is logged):
![image](https://github.com/notes-org/notes-frontend/assets/942052/85d5d190-94f6-4801-9ff1-d37cb5f97c28)

# Known Issues

- [x] When user log in validating with Enter, the view crashes. Probably a missing preventDefault() for that particular case. (**EDIT: nothing was missing, I don't understand why, but Firefox has this issue while Chrome does not**)
- [x] Some Errors (not ApiClientErrors) where silently ignored (**EDIT: they are now properly rethrowed**) 